### PR TITLE
Taille des icônes des forums et catégories

### DIFF
--- a/Controller/ForumAppController.php
+++ b/Controller/ForumAppController.php
@@ -17,7 +17,7 @@ class ForumAppController extends AppController
 
     public $atualTheme;
 
-    protected $version = '1.4.3';
+    protected $version = '1.4.4';
 
 
     protected function date($date, $day = true)

--- a/Controller/ForumAppController.php
+++ b/Controller/ForumAppController.php
@@ -211,9 +211,11 @@ class ForumAppController extends AppController
 
     protected function buildUri($type, $name, $id, $anchor =  '')
     {
-        if(!empty($anchor)){
+        $name = h($name);
+
+        if (!empty($anchor)) {
             return $this->base.'/'.$type.'/'.$this->replaceSpace($name).'.'.$id.'/#'.$anchor;
-        }else{
+        } else {
             return $this->base.'/'.$type.'/'.$this->replaceSpace($name).'.'.$id.'/';
         }
     }

--- a/Controller/ForumController.php
+++ b/Controller/ForumController.php
@@ -797,7 +797,7 @@ class ForumController extends ForumAppController
                 $msgreports[$key]['MsgReport']['user'] = $this->gUBY($msgreport['MsgReport']['id_user']);
                 $msgreports[$key]['MsgReport']['date'] = $this->dateAndTime($msgreport['MsgReport']['date']);
                 $idTopic = $this->Topic->getUniqMessage($msgreport['MsgReport']['id_msg'])['id_topic'];
-                $msgreports[$key]['MsgReport']['href'] = $this->replaceSpace($this->Topic->getTitleTopic($idTopic)).'.'.$this->Topic->getIdTopic($idTopic);
+                $msgreports[$key]['MsgReport']['href'] = $this->buildUri('topic', $this->Topic->getTitleTopic($idTopic), $idTopic);
             }
 
             $theme = $this->theme();
@@ -1461,7 +1461,7 @@ class ForumController extends ForumAppController
                 $msgreports[$key]['MsgReport']['user'] = $this->gUBY($msgreport['MsgReport']['id_user']);
                 $msgreports[$key]['MsgReport']['date'] = $this->dateAndTime($msgreport['MsgReport']['date']);
                 $idTopic = $this->Topic->getUniqMessage($msgreport['MsgReport']['id_msg'])['id_topic'];
-                $msgreports[$key]['MsgReport']['href'] = $this->replaceSpace($this->Topic->getTitleTopic($idTopic)).'.'.$this->Topic->getIdTopic($idTopic);
+                $msgreports[$key]['MsgReport']['href'] = $this->buildUri('topic', $this->Topic->getTitleTopic($idTopic), $idTopic);
             }
 
             $this->set(compact('msgreports'));
@@ -1480,7 +1480,7 @@ class ForumController extends ForumAppController
             foreach ($topics as $key => $topic) {
                 $topics[$key]['Topic']['author'] = $this->gUBY($topic['Topic']['id_user']);
                 $topics[$key]['Topic']['date'] = $this->dateAndTime($topic['Topic']['date']);
-                $topics[$key]['Topic']['href'] = $this->replaceSpace($topic['Topic']['name']).'.'.$topic['Topic']['id_topic'];
+                $topics[$key]['Topic']['href'] = $this->buildUri('topic', $topic['Topic']['name'], $topic['Topic']['id_topic']);
             }
 
             $this->set(compact('topics'));

--- a/View/Forum/forum.ctp
+++ b/View/Forum/forum.ctp
@@ -172,7 +172,7 @@
                                    endforeach; ?>
 
                                    <h3 class="forum-category-title inline">
-                                       <a style="color:<?php if(!empty($internal['topic_color'])) echo $internal['topic_color']; ?>" href="<?= h($topic['Topic']['href']); ?>"><?= $this->Text->truncate(h($topic['Topic']['name']), 50); ?></a>
+                                       <a style="color:<?php if(!empty($internal['topic_color'])) echo $internal['topic_color']; ?>" href="<?= $topic['Topic']['href']; ?>"><?= $this->Text->truncate(h($topic['Topic']['name']), 50); ?></a>
                                    </h3>
                                    <div class="forum-category-description">
                                        <a href="<?= $this->Html->url('/user/'.$topic['Topic']['author'].'.'.$topic['Topic']['id_user'].'/'); ?>"><?= $topic['Topic']['author']; ?></a>, <?= $topic['Topic']['date']; ?>

--- a/config.json
+++ b/config.json
@@ -118,7 +118,7 @@
     "Forum": "/forum"
   },
   "author":"PHPierre",
-  "version":"1.4.3",
+  "version":"1.4.4",
   "apiID":-1,
   "useEvents":false,
   "permissions" : {


### PR DESCRIPTION
Bonjour,

Les icônes des catégories apparaissent dans une taille disproportionnée comparées à celle de leur forum parent comme sur ce screen : http://tinyurl.com/y77845kw

Je n'ai pas trouvé de paramètres de personnalisation permettant d'en régler la taille.
Pensez-vous qu'il serait possible dans la prochaine mise à jour de réduire la taille des icônes de catégorie ?

Je vous en remercie d'avance.

Cordialement,
Mr_Kittle.